### PR TITLE
Add script for converting interaction databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,5 +85,19 @@ Here are some instructions in case users might encounter issues during installat
 - Install [ComplexHeatmap](https://github.com/jokergoo/ComplexHeatmap) using `devtools::install_github("jokergoo/ComplexHeatmap")`. 
 - Install [circlize](https://github.com/jokergoo/circlize) using `devtools::install_github("jokergoo/circlize")`. 
 - Please see the instructions for installation of `Seurat` or `SeuratObject` via the link [Seurat](https://satijalab.org/seurat/articles/install.html) or [SeuratObject](https://github.com/mojaveazure/seurat-object).
+
+## Interaction databases in Python
+
+The Python package expects interaction databases in a simple JSON or pickle
+format. Each interaction is stored under its name and contains the fields listed
+in ``neuronchat.db``.  To create such files from the ``.rda`` databases
+distributed with the R package, use the helper script ``scripts/convert_rda.py``.
+
+Example::
+
+    python scripts/convert_rda.py data/interactionDB_mouse.rda interactionDB_mouse.json
+
+The resulting JSON file can be loaded with :func:`neuronchat.load_interactionDB`.
   
  
+

--- a/python/neuronchat/db.py
+++ b/python/neuronchat/db.py
@@ -1,4 +1,29 @@
-"""Interaction database utilities."""
+"""Interaction database utilities.
+
+The Python API expects interaction databases to be provided as JSON files.  A
+database is a mapping from the interaction name to an object with the
+following keys::
+
+    {
+        "interaction_name": str,
+        "lig_contributor": [str, ...],
+        "receptor_subunit": [str, ...],
+        "lig_contributor_group": [int, ...],
+        "lig_contributor_coeff": [float, ...],
+        "receptor_subunit_group": [int, ...],
+        "receptor_subunit_coeff": [float, ...],
+        "targets_up": [str, ...],
+        "targets_down": [str, ...],
+        "activator": [str, ...],
+        "inhibitor": [str, ...],
+        "interactors": [str, ...],
+        "interaction_type": str,
+        "ligand_type": str,
+    }
+
+The ``scripts/convert_rda.py`` helper converts the ``.rda`` databases shipped
+with the R package into this JSON structure.
+"""
 
 from __future__ import annotations
 

--- a/scripts/convert_rda.py
+++ b/scripts/convert_rda.py
@@ -1,0 +1,46 @@
+import argparse
+import json
+import pickle
+from pathlib import Path
+
+from rpy2 import robjects
+from rpy2.robjects import default_converter
+from rpy2.robjects import pandas2ri
+from rpy2.robjects.conversion import localconverter
+
+
+def rda_to_python(path: Path):
+    """Load a single object from an R ``.rda`` file and return it as a
+    Python object using :mod:`rpy2` conversions."""
+    env = robjects.Environment()
+    robjects.r["load"](str(path), env)
+    if len(env) != 1:
+        raise ValueError("Expected a single object in the .rda file")
+    obj = next(env.values())
+    with localconverter(default_converter + pandas2ri.converter):
+        return robjects.conversion.rpy2py(obj)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert an R .rda file to JSON or pickle for use in Python"
+    )
+    parser.add_argument("rda_path", help="path to .rda file")
+    parser.add_argument(
+        "output", help="output filename (.json or .pkl/.pickle)")
+    args = parser.parse_args()
+
+    data = rda_to_python(Path(args.rda_path))
+    out_path = Path(args.output)
+    if out_path.suffix == ".json":
+        with open(out_path, "w") as fh:
+            json.dump(data, fh)
+    elif out_path.suffix in {".pkl", ".pickle"}:
+        with open(out_path, "wb") as fh:
+            pickle.dump(data, fh)
+    else:
+        raise ValueError("Output file must end with .json, .pkl or .pickle")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a helper script `scripts/convert_rda.py` to convert `.rda` files to JSON or pickle via rpy2
- document the expected JSON structure in `python/neuronchat/db.py`
- describe how to use the conversion helper in README

## Testing
- `pytest -q`
- `python scripts/convert_rda.py data/interactionDB_mouse.rda out.json` *(fails: ModuleNotFoundError: No module named 'rpy2')*

------
https://chatgpt.com/codex/tasks/task_e_68428324083083308947301dd0c9abd9