### PR TITLE
Add additional analysis functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ requires-python = ">=3.8"
 [project.optional-dependencies]
 plots = ["matplotlib", "seaborn"]
 ann = ["anndata"]
+analysis = ["scikit-learn"]
 
 [tool.setuptools.packages.find]
 where = ["python"]

--- a/python/neuronchat/__init__.py
+++ b/python/neuronchat/__init__.py
@@ -4,13 +4,33 @@ from .core import (
     NeuronChat,
     net_aggregation,
     computeNetSimilarityPairwise_Neuron,
+    computeNetSimilarity_Neuron,
+    selectK_Neuron,
+    identifyCommunicationPatterns_Neuron,
+    rankNet_Neuron,
+    compareInteractions_Neuron,
 )
 from .db import load_interactionDB, update_interactionDB
+from .visualization import (
+    netVisual_circle_neuron,
+    heatmap_single,
+    netVisual_embedding_Neuron,
+    netVisual_embeddingPairwise_Neuron,
+)
 
 __all__ = [
     "NeuronChat",
     "net_aggregation",
     "computeNetSimilarityPairwise_Neuron",
+    "computeNetSimilarity_Neuron",
+    "selectK_Neuron",
+    "identifyCommunicationPatterns_Neuron",
+    "rankNet_Neuron",
+    "compareInteractions_Neuron",
+    "netVisual_circle_neuron",
+    "heatmap_single",
+    "netVisual_embedding_Neuron",
+    "netVisual_embeddingPairwise_Neuron",
     "load_interactionDB",
     "update_interactionDB",
 ]


### PR DESCRIPTION
## Summary
- extend optional dependencies for sklearn
- implement computeNetSimilarity_Neuron and NMF pattern routines
- add ranking and comparison helpers
- add simple embedding visualizations
- export new APIs

## Testing
- `pip install -e .[plots,ann,analysis]`
- `python - <<'PY'
import neuronchat
print('OK', neuronchat.__all__[:5])
PY
`
- `python - <<'PY'
import numpy as np
from neuronchat.core import NeuronChat, computeNetSimilarity_Neuron
obj = NeuronChat()
obj.data_signaling = __import__('pandas').DataFrame({'cell_subclass':['A','B','A','B'], 'g1':[1,2,3,4], 'g2':[2,1,0,1]})
obj.DB={'lr':{'lig_contributor':['g1'], 'lig_contributor_group':[1], 'lig_contributor_coeff':[1], 'receptor_subunit':['g2'], 'receptor_subunit_group':[1], 'receptor_subunit_coeff':[1]}}
obj.run_NeuronChat(sender=['A','B'], receiver=['A','B'], M=0)
computeNetSimilarity_Neuron(obj)
print('similarity', obj.net_analysis['similarity']['functional']['matrix'])
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6842642000988330b4f1457c670ecf5a